### PR TITLE
Clarity tweak on EvaluatingChatAssistant

### DIFF
--- a/examples/EvaluatingChatAssistant/EvaluatingChatAssistant.ipynb
+++ b/examples/EvaluatingChatAssistant/EvaluatingChatAssistant.ipynb
@@ -432,7 +432,7 @@
     }
    ],
    "source": [
-    "//NOTE we added chat_history here",
+    "// NOTE we added chat_history here",
     "const experimentData = dataset.map((data) => ({\n",
     "  input: { input: data.input, chat_history: data.chat_history },\n",
     "  expected: data.expected,\n",
@@ -521,7 +521,7 @@
    "source": [
     "We update the parameter to the task function to accept both the `input` string and the `chat_history` array and add the `chat_history` into the messages array in the chat completion request, done here using the spread `...` syntax.\n",
     "\n",
-    "Please note that we changed the format of `experimentData`, and the parameters to the `Factual` function to align with these changes."
+    "Please note that we changed the format of `experimentData` and the parameters to the `Factual` function to align with these changes."
    ]
   },
   {

--- a/examples/EvaluatingChatAssistant/EvaluatingChatAssistant.ipynb
+++ b/examples/EvaluatingChatAssistant/EvaluatingChatAssistant.ipynb
@@ -432,6 +432,7 @@
     }
    ],
    "source": [
+    "//NOTE we added chat_history here",
     "const experimentData = dataset.map((data) => ({\n",
     "  input: { input: data.input, chat_history: data.chat_history },\n",
     "  expected: data.expected,\n",
@@ -520,7 +521,7 @@
    "source": [
     "We update the parameter to the task function to accept both the `input` string and the `chat_history` array and add the `chat_history` into the messages array in the chat completion request, done here using the spread `...` syntax.\n",
     "\n",
-    "We also need to update the `experimentData` and `Factual` function parameters to align with these changes."
+    "Please note that we changed the format of `experimentData`, and the parameters to the `Factual` function to align with these changes."
    ]
   },
   {


### PR DESCRIPTION
Make more clear that experimentData was changed to include chat_history - I lost a bunch of time not noticing that, but more importantly, burned all my free tier credits :'(