### PR TITLE
remove banners and fix callouts

### DIFF
--- a/examples/ClassifyingNewsArticles/ClassifyingNewsArticles.ipynb
+++ b/examples/ClassifyingNewsArticles/ClassifyingNewsArticles.ipynb
@@ -13,13 +13,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {

--- a/examples/OTEL-logging/otel-logging.mdx
+++ b/examples/OTEL-logging/otel-logging.mdx
@@ -24,10 +24,10 @@ Then, we’ll need to create a `.env` file to set the required environment varia
 OPENAI_API_KEY=<your-api-key>
 ```
 
-<Callout type="info">
+<Note>
   You can also use the OpenAI API by adding your Braintrust API key and using
   the Braintrust [AI Proxy](/docs/guides/proxy).
-</Callout>
+</Note>
 
 ## Setting up OTel
 
@@ -46,13 +46,13 @@ BRAINTRUST_PARENT=project_name:<Your Project Name>
 
 Replace `<Your API Key>` with your Braintrust API key, and `<Your Project Name>` with the name of the project in Braintrust where you'd like to store your logs.
 
-<Callout type="info">
+<Note>
   The `BRAINTRUST_PARENT` environment variable sets the trace's parent project
   or experiment. You can use a prefix like `project_id:`, `project_name:`, or
   `experiment_id:` here, or pass in a [**span
   slug**](/docs/guides/traces#distributed-tracing) (`span.export()`) to nest the
   trace under a span within the parent object.
-</Callout>
+</Note>
 
 Create a new file called `instrumentation.ts` to set up the Braintrust span processor:
 

--- a/examples/ToolOCR/ToolOCR.mdx
+++ b/examples/ToolOCR/ToolOCR.mdx
@@ -42,11 +42,11 @@ of your account.
 
 Optical character recognition, or OCR, is any type of technology that converts images of typed, handwritten or printed text into machine-encoded text. There are many well known libraries for OCR — in this cookbook, we’ll use [OCR.Space](https://ocr.space/), a free API you can use for testing without creating an account.
 
-<Callout type="info">
+<Note>
   For this cookbook, we're using the free version of OCR.Space that limits the
   number of requests. You may exceed rate limits and need to upgrade your
   account to experiment further with this application.
-</Callout>
+</Note>
 
 In Braintrust, you can create tools and then run them in the UI, API, and, of course, via prompts. This will make it easier to iterate on your prompt without having to worry about the OCR logic.
 
@@ -123,10 +123,10 @@ If you visit the **Logs** tab, you can check out detailed logs for each call:
 
 ![Expanded log](assets/log.png)
 
-<Callout type="info">
+<Note>
   We recommend using code-based prompts to initialize projects, but we'll show
   how convenient it is to tweak your prompts in the UI in a moment.
-</Callout>
+</Note>
 
 ## Create a playground
 

--- a/examples/ToolRAG/ToolRAG.mdx
+++ b/examples/ToolRAG/ToolRAG.mdx
@@ -53,10 +53,10 @@ PINECONE_API_KEY=<your-pinecone-api-key>
 Finally, make sure to set your `OPENAI_API_KEY` environment variable in the [AI providers](https://www.braintrust.dev/app/braintrustdata.com/settings/secrets) section
 of your account, and set the `PINECONE_API_KEY` environment variable in the [Environment variables](https://www.braintrust.dev/app/settings?subroute=env-vars) section.
 
-<Callout type="info">
+<Note>
   We'll use the local environment variables to embed and upload the vectors, and
   the Braintrust variables to run the RAG tool and LLM calls remotely.
-</Callout>
+</Note>
 
 ## Upload the vectors
 
@@ -156,10 +156,10 @@ If you visit the **Logs** tab, you can check out detailed logs for each call:
 
 ![Prompt logs](./assets/Prompt-logs.png)
 
-<Callout type="info">
+<Note>
   We recommend using code-based prompts to initialize projects, but we'll show
   how convenient it is to tweak your prompts in the UI in a moment.
-</Callout>
+</Note>
 
 ## Import a dataset
 

--- a/examples/VercelAISDKTracing/vercel-ai-sdk-tracing.mdx
+++ b/examples/VercelAISDKTracing/vercel-ai-sdk-tracing.mdx
@@ -75,7 +75,7 @@ The Braintrust SDK provides functions to "wrap" models, automatically logging in
 
 The `wrapAISDKModel` function only traces the inputs and outputs of the model. It does not trace intermediary steps such as tool calls that may be invoked during the model's execution. Later in the cookbook, we will explore how to use `wrapTraced` to trace tool calls and nested functions.
 
-<Callout type="info">
+<Note>
   The `wrapAISDKModel` must be used with a Vercel interface (not a model
   interface directly from the OpenAI, Anthropic, or other first-party libraries
   from model providers). If you are not using Vercel model interfaces (such as
@@ -83,7 +83,7 @@ The `wrapAISDKModel` function only traces the inputs and outputs of the model. I
   [wrap your model
   clients](https://www.braintrust.dev/docs/guides/traces/customize#wrapping-llm-clients)
   with `wrapOpenAI` or `wrapAnthropic`.
-</Callout>
+</Note>
 
 To correctly wrap the model client in our weather app example, your model client instantiation code should look like this after uncommenting the proper lines:
 

--- a/registry.yaml
+++ b/registry.yaml
@@ -60,7 +60,6 @@
     - assertions
     - tools
   logo: https://cdn.zapier.com/zapier/images/favicon.ico
-  banner: /images/cookbook-banners/Zapier.png
 - title: AI Search Bar
   path: examples/AISearch/ai_search_evals.ipynb
   date: 2024-03-04
@@ -143,7 +142,6 @@
   date: 2024-08-28
   authors:
     - ornellaaltunyan
-  banner: /images/cookbook-banners/AI-app.png
   tags:
     - evals
     - logging


### PR DESCRIPTION
There were 2 banners left and both of them had old wordmarks so I just deleted them. If it's really important we add them back (like if we needed it there for a partnership with Zapier or something) we need to make new images with our new wordmark. I also removed an empty codeblock and converted all `<Info>` blocks to `<Note>` to match mintlify convention.