### PR TITLE
Fix broken links in cookbook recipes

### DIFF
--- a/examples/APIAgent-Py/APIAgent.ipynb
+++ b/examples/APIAgent-Py/APIAgent.ipynb
@@ -836,7 +836,7 @@
     "### Creating datasets\n",
     "\n",
     "Let's create two datasets: one for good answers and the other for hallucinations. To keep things simple, we'll assume that the\n",
-    "non-hallucinations are correct, but in a real-world scenario, you could [collect user feedback](/docs/instrument/custom-tracing#user-feedback)\n",
+    "non-hallucinations are correct, but in a real-world scenario, you could [collect user feedback](/docs/instrument/user-feedback#capture-user-feedback)\n",
     "and treat positively rated feedback as ground truth.\n",
     "\n",
     "![Dataset setup](./assets/dataset-setup.gif)\n",

--- a/examples/AgentWhileLoop/AgentWhileLoop.mdx
+++ b/examples/AgentWhileLoop/AgentWhileLoop.mdx
@@ -265,5 +265,5 @@ Additionally, if you run `npm run eval:tools`, you can clearly see the differenc
 Start building your own while loop agent by picking a specific use case and 2-3 tools, then gradually add complexity.
 
 - [Log](/docs/observe/view-logs) all interactions and build [evaluation datasets](/docs/annotate/datasets) from real usage patterns
-- Use [Loop](/docs/observe/loop) to improve prompts, scorers, and datasets
+- Use [Loop](/docs/observe/index#use-loop) to improve prompts, scorers, and datasets
 - Explore more agent patterns in the [cookbook](/docs/cookbook)

--- a/examples/Loop/loop.mdx
+++ b/examples/Loop/loop.mdx
@@ -1,6 +1,6 @@
 # Using Loop for AI development
 
-[Loop](/docs/observe/loop) is a built-in AI assistant that helps you throughout the AI product development process in Braintrust. From creating scorers and generating datasets to analyzing logs and improving prompts, Loop is available throughout the product to help with your workflows. This guide shows how you can use Loop to build, evaluate, and improve a weather agent, demonstrating how Loop can make common AI development tasks easier and more accessible.
+[Loop](/docs/observe/index#use-loop) is a built-in AI assistant that helps you throughout the AI product development process in Braintrust. From creating scorers and generating datasets to analyzing logs and improving prompts, Loop is available throughout the product to help with your workflows. This guide shows how you can use Loop to build, evaluate, and improve a weather agent, demonstrating how Loop can make common AI development tasks easier and more accessible.
 
 By the end of this guide, you'll learn how to:
 
@@ -295,6 +295,6 @@ Now that you've seen how Loop can accelerate your AI development workflow, try a
 
 For more information on Loop and other Braintrust features:
 
-- Learn more about [Loop](/docs/observe/loop)
+- Learn more about [Loop](/docs/observe/index#use-loop)
 - Explore [logging](/docs/observe/view-logs) and [experiments](/docs/evaluate/run-evaluations)
 - Check out other [cookbook recipes](/cookbook)

--- a/examples/OTEL-logging/otel-logging.mdx
+++ b/examples/OTEL-logging/otel-logging.mdx
@@ -147,7 +147,7 @@ Because this application is using multi-step streaming and tool calls, the logs 
 
 ### Filtering your logs
 
-Run a couple more queries in the app and notice the logs that are generated. Our app is logging both `GET` and `POST` requests, but we’re most interested in the `POST` requests since they contain our LLM calls. We can apply a filter using the [BTQL](/docs/reference/btql) query `Name LIKE 'POST%'` so that we only see the traces we care about:
+Run a couple more queries in the app and notice the logs that are generated. Our app is logging both `GET` and `POST` requests, but we’re most interested in the `POST` requests since they contain our LLM calls. We can apply a filter using the BTQL query `Name LIKE 'POST%'` so that we only see the traces we care about:
 
 ![Filter using BTQL](assets/add-post-filter.gif)
 


### PR DESCRIPTION
Fixes broken links across four cookbook recipes:

- **APIAgent-Py**: `/instrument/custom-tracing#user-feedback` → `/instrument/user-feedback#capture-user-feedback`
- **Loop** and **AgentWhileLoop**: `/observe/loop` → `/observe/index#use-loop`
- **OTEL-logging**: Remove broken `[BTQL](/reference/btql)` link (keep as plain text)

Co-Authored-By: Oz <oz-agent@warp.dev>