### PR TITLE
Fix HF agent traces analysis query to use metadata.* fields

### DIFF
--- a/examples/HuggingFaceAgentTraces/HuggingFaceAgentTraces.mdx
+++ b/examples/HuggingFaceAgentTraces/HuggingFaceAgentTraces.mdx
@@ -167,13 +167,13 @@ This is more than tidy organization. In our analysis, Topics independently confi
 The reason to put traces in Braintrust is to ask structured questions across all of them at once. Every span carries queryable metadata, so you can group by benchmark, harness, and model in a single query:
 
 ```sql
-SELECT benchmark, harness, model,
+SELECT metadata.benchmark, metadata.harness, metadata.models,
        COUNT(*) AS n,
-       AVG(metrics.tokens) AS avg_tokens,
+       AVG(metadata.total_tokens) AS avg_tokens,
        AVG(scores.task_success) AS success_rate
 FROM project_logs
 WHERE scores.task_success IS NOT NULL
-GROUP BY benchmark, harness, model
+GROUP BY metadata.benchmark, metadata.harness, metadata.models
 ORDER BY success_rate DESC
 ```
 


### PR DESCRIPTION
The "Slicing the results" query in the HuggingFaceAgentTraces cookbook read top-level `benchmark`/`harness`/`model` columns and `metrics.tokens`, but the importer (`import_logs.py` `METADATA_COLS`) writes those under `metadata.*`, and the scored root session spans carry the session total as `metadata.total_tokens` (root spans have no `metrics.tokens`). As written, the query fails on missing fields / returns null token averages.

Fix: use `metadata.benchmark`, `metadata.harness`, `metadata.models`, and `metadata.total_tokens` in SELECT and GROUP BY. Caught in review on braintrustdata/braintrust#16126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)