### PR TITLE
Remove DELETE /v1/acl from the doc sample

### DIFF
--- a/examples/Realtime/realtime-rag/utils/docs-sample/Acls.mdx
+++ b/examples/Realtime/realtime-rag/utils/docs-sample/Acls.mdx
@@ -5,30 +5,25 @@ _openapi:
   toc:
     - depth: 2
       title: List acls
-      url: '#list-acls'
+      url: "#list-acls"
     - depth: 2
       title: Create acl
-      url: '#create-acl'
-    - depth: 2
-      title: Delete single acl
-      url: '#delete-single-acl'
+      url: "#create-acl"
     - depth: 2
       title: Get acl
-      url: '#get-acl'
+      url: "#get-acl"
     - depth: 2
       title: Delete acl
-      url: '#delete-acl'
+      url: "#delete-acl"
     - depth: 2
       title: Batch update acls
-      url: '#batch-update-acls'
+      url: "#batch-update-acls"
   structuredData:
     headings:
       - content: List acls
         id: list-acls
       - content: Create acl
         id: create-acl
-      - content: Delete single acl
-        id: delete-single-acl
       - content: Get acl
         id: get-acl
       - content: Delete acl
@@ -45,8 +40,6 @@ _openapi:
           as the one specified in the request, will return the existing acl
           unmodified
         heading: create-acl
-      - content: Delete a single acl
-        heading: delete-single-acl
       - content: Get an acl object by its id
         heading: get-acl
       - content: Delete an acl object by its id
@@ -60,4 +53,14 @@ _openapi:
 
 import jsonSpec from "@braintrust/openapi/spec.json";
 
-<APIPage document={jsonSpec} operations={[{"method":"get","path":"/v1/acl"},{"method":"post","path":"/v1/acl"},{"method":"delete","path":"/v1/acl"},{"method":"get","path":"/v1/acl/{acl_id}"},{"method":"delete","path":"/v1/acl/{acl_id}"},{"method":"post","path":"/v1/acl/batch-update"}]} hasHead={true} />
+<APIPage
+  document={jsonSpec}
+  operations={[
+    { method: "get", path: "/v1/acl" },
+    { method: "post", path: "/v1/acl" },
+    { method: "get", path: "/v1/acl/{acl_id}" },
+    { method: "delete", path: "/v1/acl/{acl_id}" },
+    { method: "post", path: "/v1/acl/batch-update" },
+  ]}
+  hasHead={true}
+/>


### PR DESCRIPTION
Remove the occurrences of the 
DELETE /v1/acl route, as it is being removed

And prettier was unhappy which inflated the diff
Doc update: https://github.com/braintrustdata/braintrust-openapi/pull/208